### PR TITLE
#234: docs: rewrite README from current codebase and PRD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ docker/.env.*.local
 .understand-anything/intermediate/
 .understand-anything/tmp/
 .understand-anything/.trash-*/
+.understand-anything/.understandignore

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -22,7 +22,8 @@ config:
   MD033: false # no-inline-html
 
   # Still useful signals.
-  MD009: true # trailing spaces
+  MD009:
+    br_spaces: 2 # allow two trailing spaces for intentional Markdown line breaks
 
 ignores:
   - "**/node_modules/**"

--- a/README.md
+++ b/README.md
@@ -1,274 +1,260 @@
 # Babblr
 
-A desktop language learning app that lets you speak naturally with an AI tutor. Learn Spanish, Italian, German, French, or Dutch through immersive conversations with adaptive difficulty.
+A desktop language learning app that lets you speak naturally with an AI tutor. Practice **English, Spanish, Italian, German, French, and Dutch** through immersive conversations, structured grammar and vocabulary lessons, and CEFR placement assessments — all with adaptive difficulty (A1–C2).
+
+Babblr runs on your machine: your conversations stay local, and you choose which AI backend to use — a fully offline local model (Ollama), or a hosted provider (Claude, Gemini) when you want higher quality.
 
 ## Features
 
-🗣️ **Natural Conversation**: Speak naturally with Claude AI, not like a textbook  
-🎤 **Voice Recording**: Record your speech and get instant transcription via Whisper  
-✨ **Error Correction**: Get gentle, contextual corrections on grammar and vocabulary  
-🔊 **Text-to-Speech**: Hear natural pronunciation with multi-language TTS  
-📚 **Vocabulary Tracking**: Automatically track new words and phrases  
-🎯 **Adaptive Difficulty**: CEFR levels (A1-C2) that match your skills  
-💼 **Topic-Based Learning**: Choose conversation topics (business, travel, shopping, restaurants, etc.)  
-💾 **Conversation History**: Save and continue your learning sessions
+🗣️ **Natural conversation** — Practice speaking with an AI tutor that adapts to your level, not a scripted textbook  
+🎤 **Voice input** — Record your speech and get instant transcription via local Whisper  
+✨ **Adaptive error correction** — Gentle, level-appropriate corrections (beginners are corrected softly and rarely; advanced learners more strictly)  
+🔊 **Text-to-speech** — Hear natural pronunciation, with playback speed tuned to your level  
+📚 **Vocabulary lessons** — Structured, topic-based vocabulary with translations and examples  
+📖 **Grammar lessons with spaced repetition** — Grammar rules and exercises scheduled for review based on your mastery  
+🎯 **CEFR assessments** — Placement tests that score you per skill (grammar, vocabulary, listening) and recommend a level  
+📈 **Progress tracking** — Follow your level and lesson history over time  
+🔌 **Swappable AI backends** — Local Ollama (offline, default), Claude, or Gemini via a single provider abstraction  
+💾 **Conversation history** — Save and resume your learning sessions
 
-## What It Looks Like
+## How Babblr teaches
 
-### Home Screen
-Select your target language, difficulty level, and access recent conversations:
+Babblr is not a thin wrapper over a chatbot. Its tutoring behavior is grounded in second-language-acquisition research and encoded in the backend:
+
+- **Comprehensible input (Krashen's _i+1_)** — The tutor targets language just above your current level: you understand most of what you hear and stretch for the rest. CEFR level templates (`backend/templates/prompts/`) cap sentence length, vocabulary size, and grammar complexity per level.
+- **Communicative approach** — Learning happens through meaningful conversation on real topics (travel, shopping, business…), not isolated drills. No streaks, XP, or leaderboards.
+- **Level-differentiated correction** — Correction strategy changes with level: at A1 the tutor ignores punctuation and diacritics and offers at most one gentle correction; higher levels get stricter, more detailed feedback.
+- **90% coverage principle** — A newer modular prompt system (`backend/app/services/modular_prompt_builder.py`) composes tutor identity, level constraints, roleplay context, and correction strategy so learners recognize ~90% of vocabulary and grammar from lessons at or below their level.
+
+For the full pedagogical rationale see [docs/prd/00-vision/product-principles.md](docs/prd/00-vision/product-principles.md); for how curriculum and lessons are generated see [docs/curriculum/lesson-creation.md](docs/curriculum/lesson-creation.md).
+
+## What it looks like
+
+The app is organized into tabs: **Home, Vocabulary, Grammar, Conversations, Assessments, Progress, and Configuration**. Active-conversation state is preserved as you switch tabs.
+
+### Home screen
+Select your target language and difficulty level, and jump back into recent conversations:
 
 ![Home Screen](docs/screenshots/home-screen.svg)
 
-### Conversation Screen
-Interact with the AI tutor through voice or text, receive corrections, and track your progress:
+### Conversation screen
+Talk or type with the AI tutor, receive corrections, and hear responses read aloud:
 
 ![Conversation Screen](docs/screenshots/conversation-screen.svg)
 
-### Assessment Screen
-Take CEFR placement tests to determine your proficiency level and get personalized recommendations:
+### Assessment screen
+Take a CEFR placement test to determine your level, with a per-skill breakdown and recommendations:
 
 ![Assessment Screen](docs/screenshots/assessment-screen.svg)
 
-**Key UI Features:**
-- **Language Selection**: Choose from Spanish 🇪🇸, Italian 🇮🇹, German 🇩🇪, French 🇫🇷, or Dutch 🇳🇱
-- **Voice Input**: Green microphone button for speech-to-text
-- **Real-time Corrections**: Yellow panel shows grammar and vocabulary corrections
-- **Natural Chat Interface**: Conversational bubbles with timestamps
-- **Audio Playback**: Automatic text-to-speech for AI responses
-- **CEFR Assessments**: Placement tests with skill breakdown and level recommendations
-
 For a detailed visual walkthrough and UI specifications, see the [Visual Guide](VISUAL_GUIDE.md).
 
-## Tech Stack
+## Tech stack
 
 ### Frontend
-- **Electron**: Desktop application framework
-- **React**: UI library
-- **TypeScript**: Type-safe development
-- **Vite**: Fast build tool
+- **Electron** + **React 19** + **TypeScript** — desktop application
+- **Vite** — build tool and dev server
+- **Vitest** — unit tests
 
 ### Backend
-- **FastAPI**: Modern Python web framework
-- **OpenAI Whisper**: Speech-to-text transcription
-- **Anthropic Claude**: AI conversation and error correction
-- **Edge TTS**: Free text-to-speech synthesis
-- **SQLite**: Local database for conversations and vocabulary
+- **FastAPI** (async) — Python web framework
+- **SQLAlchemy 2 (async)** with **SQLite** by default, or **PostgreSQL** (asyncpg) under Docker
+- **LangChain** — prompt construction and provider integrations
+- **Swappable LLM providers** — Ollama (local, default), Anthropic Claude, Google Gemini, and a mock provider, behind a single factory
+- **OpenAI Whisper** — local speech-to-text (with an optional external Whisper webservice)
+- **Edge TTS** — free text-to-speech synthesis
+- **uv** — Python dependency and environment management
 
-## Getting Started
+## Getting the code
 
-### Docker (Easiest for Development)
+```bash
+git clone https://github.com/pkuppens/babblr.git
+cd babblr
+```
 
-Run the entire stack with hot-reload using Docker Compose:
+## Prerequisites
+
+- **Python 3.12+** (backend requires `>=3.12,<3.15`)
+- **Node.js 22+ LTS** (Node 24 also supported)
+- **uv** — installed automatically by the setup scripts, or manually: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **An AI backend** — either [Ollama](https://ollama.com/) for offline use (default), or an **Anthropic** / **Google** API key. See [ENVIRONMENT.md](ENVIRONMENT.md) for how to get and configure keys.
+
+> [!TIP]
+> The fastest way to run the full stack (backend, frontend, PostgreSQL, and Ollama) is Docker Compose — see below. It needs only Docker installed.
+
+## Getting started
+
+### Docker (easiest for development)
+
+Runs the entire stack with hot-reload:
 
 ```bash
 cd docker
 cp .env.template .env
-# Edit .env if you want to use Claude/Gemini instead of Ollama
+# Edit .env if you want to use Claude/Gemini instead of the bundled Ollama
 docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d
 ```
 
-This starts backend, frontend, PostgreSQL, and Ollama in containers with automatic code reloading.
+This starts backend, frontend, PostgreSQL, and Ollama with automatic code reloading. See [docker/README.md](docker/README.md) for detailed setup and troubleshooting.
 
-See [docker/README.md](docker/README.md) for detailed Docker setup and troubleshooting.
-
-### Quick Setup (Native Installation)
-
-Use the automated setup script with uv package manager:
+### Native setup (setup scripts)
 
 **Linux/macOS:**
 ```bash
-# Run the setup script (installs uv if needed)
 ./setup.sh
 ```
 
 **Windows:**
 ```cmd
-REM Run the setup script (installs uv if needed)
 setup.bat
 ```
 
-This will:
-- Install uv (fast Python package manager) if not present
-- Set up backend with uv virtual environment
-- Install all dependencies
-- Set up frontend
+The script installs `uv` if needed, creates the backend virtual environment (`backend/.venv`), and installs backend and frontend dependencies. See [backend/UV_SETUP.md](backend/UV_SETUP.md) for details.
 
-**Windows users:** Use `setup.bat` instead of `./setup.sh`
+### Manual backend setup
 
-See [backend/UV_SETUP.md](backend/UV_SETUP.md) for detailed uv usage and troubleshooting.
-
-### Prerequisites
-
-- **Python 3.12+** (3.13 not required, but 3.12 recommended for latest features)
-- **Node.js 22+ LTS** (or Node.js 24+ for latest performance and security)
-- **uv** (automatically installed by setup.sh, or install manually: `curl -LsSf https://astral.sh/uv/install.sh | sh`)
-- **Anthropic API Key** - See [ENVIRONMENT.md](ENVIRONMENT.md) for how to get and configure API keys
-
-### Manual Backend Setup
-
-1. Install uv (if not already installed):
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-2. Navigate to the backend directory:
 ```bash
 cd backend
+
+# Create the virtual environment and install dependencies
+uv sync --group dev
+
+# Configure environment (see ENVIRONMENT.md for details)
+cp .env.example .env
+# Edit .env — set LLM_PROVIDER and any API keys you need
+
+# Run the backend
+uv run uvicorn app.main:app --reload
+# or, from the project root: ./run-backend.sh
 ```
 
-3. Create virtual environment and install dependencies with uv:
-```bash
-# Create venv and install all dependencies
-uv venv
-uv pip install -e ".[dev]"
-```
+The API is served at http://localhost:8000. Confirm it is up by opening the interactive docs at http://localhost:8000/docs.
 
-4. **Configure environment variables:**
+### Frontend setup
 
-   See **[ENVIRONMENT.md](ENVIRONMENT.md)** for detailed instructions on:
-   - Getting your Anthropic API key
-   - All available configuration options
-   - Troubleshooting common issues
-
-   **Quick start:**
-   ```bash
-   cp .env.example .env
-   # Edit .env and add your ANTHROPIC_API_KEY
-   ```
-
-5. Run the backend:
-```bash
-# Using uv (recommended)
-source .venv/bin/activate
-babblr-backend
-
-# Or using the run script
-cd ..
-./run-backend.sh
-```
-
-The API will be available at http://localhost:8000
-
-### Frontend Setup
-
-1. Navigate to the frontend directory:
 ```bash
 cd frontend
-```
-
-2. Install dependencies:
-```bash
 npm install
-```
-
-3. Run in development mode:
-```bash
 npm run electron:dev
 ```
 
-This will start both the Vite dev server and Electron.
+This starts the Vite dev server (on port 5173) and launches Electron once it is ready.
 
-### Building for Production
+### Building for production
 
-Build the frontend:
 ```bash
 cd frontend
-npm run build
-npm run electron:build
+npm run build            # TypeScript + Vite build
+npm run electron:build   # Create a distributable via electron-builder
 ```
 
-The built application will be in `frontend/release/`.
+The built application lands in `frontend/release/`.
 
 ## Usage
 
-1. **Start a Conversation**: Select your target language, difficulty level, and choose a conversation topic
-2. **Assessment (optional)**: Take a placement test instead of selecting the difficulty level to get a recommended CEFR level (A1-C2)
-3. **Talk or Type**: Use the microphone button to speak, or type your message
-4. **Get Feedback**: See corrections and explanations for your mistakes
-5. **Listen**: Hear the AI tutor's response with natural pronunciation
-6. **Track Progress**: Review your conversation history and vocabulary
+1. **Choose a language and level** on the Home screen — or take a placement test in **Assessments** to get a recommended CEFR level (A1–C2).
+2. **Start a conversation** and pick a topic (business, travel, shopping, restaurants…).
+3. **Talk or type** — use the microphone to speak, or type your message.
+4. **Get feedback** — see level-appropriate corrections and explanations.
+5. **Study lessons** — reinforce with Grammar and Vocabulary lessons; grammar items return for spaced-repetition review.
+6. **Track progress** — review your level and history on the Progress screen.
 
-## Supported Languages
+## Supported languages
 
+Full conversational practice (speech-to-text **and** text-to-speech):
+
+- 🇬🇧 English
 - 🇪🇸 Spanish
 - 🇮🇹 Italian
 - 🇩🇪 German
 - 🇫🇷 French
 - 🇳🇱 Dutch
 
-## API Documentation
+Portuguese is available for text-to-speech (listening) but not yet for speech input. See [backend/app/services/language_catalog.py](backend/app/services/language_catalog.py) for the authoritative list.
 
-Once the backend is running, visit:
-- **Swagger UI**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
-
-## Testing
-
-### Backend Tests
-
-Run unit tests (don't require backend running):
-```bash
-cd backend
-pytest tests/test_unit.py -v
-```
-
-Run integration tests (requires backend to be running):
-```bash
-# Terminal 1: Start backend
-./run-backend.sh
-
-# Terminal 2: Run tests
-cd backend
-pytest tests/test_integration.py -v
-```
-
-Run all tests:
-```bash
-cd backend
-pytest tests/ -v
-```
-
-See `backend/tests/README.md` for more details.
+> [!NOTE]
+> Content depth is deepest for Spanish today; other languages have lighter seed curricula. Expanding parity across languages is active work.
 
 ## Architecture
 
 ```
 babblr/
 ├── backend/
-│   ├── app/
-│   │   ├── main.py              # FastAPI application
-│   │   ├── config.py            # Configuration
-│   │   ├── database/            # Database setup
-│   │   ├── models/              # SQLAlchemy & Pydantic models
-│   │   ├── routes/              # API endpoints
-│   │   └── services/            # AI service integrations
-│   └── requirements.txt
+│   └── app/
+│       ├── main.py                 # FastAPI entry point, router registration
+│       ├── config.py               # Settings from environment variables
+│       ├── database/               # Async SQLAlchemy setup
+│       ├── models/                 # ORM models + Pydantic schemas
+│       ├── grammar/                # Grammar lesson domain (models, service, spaced repetition)
+│       ├── routes/                 # API endpoints
+│       │   ├── chat.py             # Conversation with the LLM
+│       │   ├── conversations.py    # Conversation CRUD
+│       │   ├── topics.py           # Topic suggestions
+│       │   ├── vocabulary.py       # Vocabulary lessons
+│       │   ├── grammar.py          # Grammar lessons + exercises
+│       │   ├── lessons.py          # Unified lesson listing
+│       │   ├── assessments.py      # CEFR placement tests
+│       │   ├── progress.py         # Progress tracking
+│       │   ├── user_levels.py      # Per-user level state
+│       │   ├── stt.py              # Speech-to-text (Whisper)
+│       │   └── tts.py              # Text-to-speech (Edge TTS)
+│       └── services/
+│           ├── llm/                # Swappable LLM providers (factory + base)
+│           ├── stt/                # Swappable STT providers (local/external/mock)
+│           ├── prompt_builder.py           # CEFR prompt templates
+│           ├── modular_prompt_builder.py   # Composable prompt system ("90% coverage")
+│           ├── scoring_service.py          # Assessment scoring + recommendations
+│           ├── conversation_service.py     # Conversation business logic
+│           ├── whisper_service.py          # Local Whisper STT
+│           └── tts_service.py              # Edge TTS
 │
 └── frontend/
-    ├── electron/
-    │   └── main.js              # Electron main process
-    ├── src/
-    │   ├── components/          # React components
-    │   ├── services/            # API client
-    │   ├── types/               # TypeScript types
-    │   └── App.tsx              # Main app component
-    └── package.json
+    ├── electron/                   # Electron main process
+    └── src/
+        ├── App.tsx                 # Tab navigation + global state
+        ├── screens/                # Home, Vocabulary, Grammar, Conversations, Assessments, Progress, Configuration
+        ├── components/             # Reusable React components
+        ├── hooks/                  # Custom hooks (audio recorder, TTS, retry)
+        ├── services/               # API client + settings persistence
+        └── types/                  # TypeScript types
 ```
 
-## Development Philosophy
+The backend follows a layered design (routes → services → repositories/storage) with abstractions injected via factories, so LLM, STT, and prompt strategies can be swapped by configuration. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DATABASE_SCHEMA.md](docs/DATABASE_SCHEMA.md).
 
-This app focuses on:
+## API documentation
+
+With the backend running:
+- **Swagger UI**: http://localhost:8000/docs
+- **ReDoc**: http://localhost:8000/redoc
+
+## Testing
+
+### Backend (from `backend/`)
+
+```bash
+uv run pytest tests/test_unit.py -vv --tb=short -n 8            # Unit tests (no server)
+uv run pytest tests/test_llm_providers.py -vv --tb=short -n 8   # LLM provider tests (mocked)
+uv run pytest tests/test_integration.py -vv --tb=short -n 8     # Integration tests (server must be running)
+uv run pytest tests/ -vv --tb=short -n 8                         # All tests
+```
+
+Integration tests use the `@pytest.mark.integration` marker. See [backend/tests/README.md](backend/tests/README.md).
+
+### Frontend (from `frontend/`)
+
+```bash
+npm run test            # Run once
+npm run test:watch      # Watch mode
+npm run test:coverage   # With coverage
+```
+
+## Development philosophy
+
+Babblr focuses on:
 - **Natural conversation** over gamification
 - **Adaptive difficulty** that grows with you
 - **Immersive learning** through practical use
-- **Free/affordable** APIs and local processing
-
-## Free Tier Limits
-
-- **Claude (Anthropic)**: Check current free tier at anthropic.com
-- **Whisper**: Runs locally, no API limits
-- **Edge TTS**: Free Microsoft TTS service
+- **Privacy-first, offline-capable** operation — your data stays local, and you pick your AI provider
 
 ## Contributing
 
@@ -284,15 +270,14 @@ Babblr is a public project. Contributions are welcome — especially small, well
   - **PR submitter responsibility**: you are responsible for reviewing any AI-generated code before submitting, and for addressing review feedback.
   - **Maintainer reviews before merge**: maintainers will do an AI-assisted review and a human review before merge. We may ask for changes, or (in some cases) merge with small maintainer edits.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and [POLICIES.md](POLICIES.md) for git/commit conventions.
 
 ## Licensing
 
 Babblr is **dual-licensed**:
 
-- **Open source license (AGPL-3.0)**: You may use, modify, and distribute Babblr under the terms of the GNU Affero General Public License v3.  
-  Important: If you run a modified version and make it available to users over a network, you must offer the corresponding source code to those users (AGPL network copyleft).
-- **Commercial license**: If you want to use Babblr in a **proprietary / closed-source** product or service (for example, you cannot comply with AGPL source-sharing requirements), you must obtain a commercial license.
+- **Open source license (AGPL-3.0)**: You may use, modify, and distribute Babblr under the terms of the GNU Affero General Public License v3. If you run a modified version and make it available to users over a network, you must offer the corresponding source code to those users (AGPL network copyleft).
+- **Commercial license**: If you want to use Babblr in a **proprietary / closed-source** product or service, you must obtain a commercial license.
 
 See:
 - [LICENSE](LICENSE) (AGPL-3.0)
@@ -305,4 +290,6 @@ See:
 
 - OpenAI for Whisper
 - Anthropic for Claude
+- Google for Gemini
+- Ollama for local model serving
 - Microsoft for Edge TTS


### PR DESCRIPTION
## Summary
- Regenerates `README.md` to reflect the actual feature set, tech stack, architecture, and setup flow (Docker + native), replacing stale content.
- Allows intentional two-space Markdown line breaks in markdownlint (MD009).
- Ignores the local `.understandignore` artifact in `.gitignore`.

Closes #234

## Test plan
- [x] Review rendered README on GitHub for accuracy and formatting
- [x] `npx markdownlint-cli2 README.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)