### PR TITLE
fix(ci): reformat markdown code fences, block typescript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-react"
         update-types: ["version-update:semver-major"]
+      # @typescript-eslint has no TS7 support yet (see 8931d25)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"

--- a/backend/ADAPTIVE_PROMPTS.md
+++ b/backend/ADAPTIVE_PROMPTS.md
@@ -141,7 +141,7 @@ prompt = builder.build_prompt(
     topic="introducing yourself",
     native_language="English",
     recent_vocab=["hola", "gracias", "por favor"],
-    common_mistakes=["mixing ser and estar"]
+    common_mistakes=["mixing ser and estar"],
 )
 ```
 
@@ -149,8 +149,8 @@ prompt = builder.build_prompt(
 
 ```python
 builder.normalize_level("beginner")  # Returns "A1"
-builder.normalize_level("b2")        # Returns "B2"
-builder.normalize_level("invalid")   # Returns "A1" (default)
+builder.normalize_level("b2")  # Returns "B2"
+builder.normalize_level("invalid")  # Returns "A1" (default)
 ```
 
 ### Correction Strategies

--- a/backend/IMPLEMENTATION_SUMMARY.md
+++ b/backend/IMPLEMENTATION_SUMMARY.md
@@ -223,14 +223,14 @@ prompt = builder.build_prompt(
     topic="greetings and introductions",
     native_language="English",
     recent_vocab=["hola", "gracias", "adiós"],
-    common_mistakes=["confusing ser/estar"]
+    common_mistakes=["confusing ser/estar"],
 )
 
 # Get correction strategy
 strategy = builder.get_correction_strategy("A1")
 # Returns: {
 #   "ignore_punctuation": true,
-#   "ignore_capitalization": true, 
+#   "ignore_capitalization": true,
 #   "ignore_diacritics": true,
 #   "focus_on": ["basic_grammar", "core_vocabulary"]
 # }


### PR DESCRIPTION
## Summary
- `ruff format` was reformatting code fences inside `backend/ADAPTIVE_PROMPTS.md` and `backend/IMPLEMENTATION_SUMMARY.md` under a newer ruff version than the stale local `.venv` had, causing `Backend Lint` to fail on every open PR (#260, #261, #262).
- Dependabot re-bumped `typescript` to `^7.0.2` in #262, which `@typescript-eslint` still doesn't support (previously pinned to `6.0.3` in 8931d25). Added it to the major-version ignore list alongside react/eslint.

## Test plan
- [x] `uv run ruff format --check .` passes clean in `backend/`
- [x] pre-commit hooks passed on commit