### PR TITLE
#255: Vocab-eval research harness: judge, prompt variants, batch runner

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,20 @@
+# Babblr
+
+Babblr is a desktop language-learning app for conversational practice with an AI tutor across CEFR levels A1-C2.
+
+## Language
+
+**Tutor**:
+The AI role that converses with the student in the target language, adapting vocabulary and grammar to the student's CEFR level.
+_Avoid_: Teacher agent, teacher
+
+**Student Simulator**:
+An LLM prompted to role-play a student at a given CEFR level, producing realistic level-appropriate mistakes, used to generate conversation transcripts for evaluation without a real learner.
+_Avoid_: Fake student, mock student
+
+**Comprehensible Input Ratio**:
+The proportion of words in a tutor response that the student already knows or has been taught, versus new/unexplained words. Not a fixed number — the target ratio (e.g. ~80%) is a starting point determined by human observation of what feels understandable at a level, not a hard threshold enforced by a frequency list. New words introduced beyond this ratio should be level-appropriate (i+1: a small stretch above the student's current level, not far beyond it).
+_Avoid_: Vocabulary coverage, 90% coverage principle
+
+**LLM-as-Judge**:
+An LLM used to score a tutor/student conversation transcript against a rubric (e.g. comprehensible input ratio, level-appropriateness of new vocabulary), as a scalable stand-in for human review. Its verdicts are calibrated against a human reading the same transcripts before being trusted to score unsupervised at scale.

--- a/backend/experiments/vocab_eval/__init__.py
+++ b/backend/experiments/vocab_eval/__init__.py
@@ -1,0 +1,19 @@
+"""Vocab-eval: LLM-as-judge research harness for tutor prompt/model comparison (issue #255).
+
+Responsibilities:
+    - Generate tutor/student-simulator conversation transcripts for a given
+      (tutor model, prompt template) pair (`generate.py`).
+    - Score a transcript's comprehensible-input ratio and vocabulary
+      level-appropriateness using a second LLM as judge (`judge.py`).
+    - Run the full (tutor model x prompt) matrix and write a summary CSV
+      (`batch.py` — the entry point, run as `python -m experiments.vocab_eval.batch`).
+
+Not exported: this package has no public API surface — it is a standalone
+research spike, not a dependency of `app.*` production code. Import from the
+specific submodule you need (`experiments.vocab_eval.generate`,
+`experiments.vocab_eval.judge`, etc.) rather than from the package root.
+
+Domain terms (Tutor, Student Simulator, Comprehensible Input Ratio,
+LLM-as-Judge) are defined in `/CONTEXT.md` at the repo root — read that first.
+Per-module docstrings hold the implementation detail; this file only orients.
+"""

--- a/backend/experiments/vocab_eval/batch.py
+++ b/backend/experiments/vocab_eval/batch.py
@@ -1,0 +1,140 @@
+"""Batch runner: generates + judges transcripts across a tutor-model x prompt matrix.
+
+Standalone harness entry point for the vocab-eval research spike (issue #255).
+Runs `generate_transcript` then `judge_transcript` for every (model, prompt)
+combination and writes a summary CSV alongside the individual transcript and
+verdict JSON files.
+"""
+
+import argparse
+import asyncio
+import csv
+import logging
+from pathlib import Path
+
+from app.services.llm.providers.ollama import OllamaProvider
+from experiments.vocab_eval.generate import generate_transcript
+from experiments.vocab_eval.judge import default_judge_model, judge_transcript
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TUTOR_MODELS = [
+    "llama3.2:latest",
+    "qwen3:8b",
+    "gemma4:latest",
+    "mistral:7b",
+    "phi4:latest",
+]
+DEFAULT_TUTOR_PROMPTS = ["variant_a", "variant_b"]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_RUN_DIR = REPO_ROOT / "tmp" / "vocab-eval"
+
+
+async def run_matrix(
+    tutor_models: list[str],
+    tutor_prompts: list[str],
+    language: str,
+    level: str,
+    topic: str,
+    turns: int,
+    judge_model: str | None,
+    ollama_base_url: str,
+    run_dir: Path,
+) -> list[dict]:
+    """Generate + judge one transcript per (model, prompt) combo. Returns summary rows."""
+    transcripts_dir = run_dir / "transcripts"
+    verdicts_dir = run_dir / "verdicts"
+    rows: list[dict] = []
+
+    for tutor_model in tutor_models:
+        for tutor_prompt in tutor_prompts:
+            logger.info("Generating: model=%s prompt=%s", tutor_model, tutor_prompt)
+            transcript = await generate_transcript(
+                tutor_model=tutor_model,
+                tutor_prompt=tutor_prompt,
+                language=language,
+                level=level,
+                topic=topic,
+                turns=turns,
+                ollama_base_url=ollama_base_url,
+            )
+            transcript_path = transcript.save(transcripts_dir)
+
+            resolved_judge_model = judge_model or default_judge_model(tutor_model)
+            judge_provider = OllamaProvider(base_url=ollama_base_url, model=resolved_judge_model)
+            try:
+                verdict = await judge_transcript(transcript, str(transcript_path), judge_provider)
+            finally:
+                await judge_provider.close()
+            verdict_path = verdict.save(verdicts_dir)
+
+            rows.append(
+                {
+                    "tutor_model": tutor_model,
+                    "tutor_prompt": tutor_prompt,
+                    "judge_model": resolved_judge_model,
+                    "comprehensible_ratio": verdict.comprehensible_ratio,
+                    "vocabulary_level_appropriate": verdict.vocabulary_level_appropriate,
+                    "transcript_path": str(transcript_path),
+                    "verdict_path": str(verdict_path),
+                }
+            )
+            logger.info(
+                "Judged: model=%s prompt=%s ratio=%.2f appropriate=%s",
+                tutor_model,
+                tutor_prompt,
+                verdict.comprehensible_ratio,
+                verdict.vocabulary_level_appropriate,
+            )
+
+    return rows
+
+
+def write_summary_csv(rows: list[dict], path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(rows[0].keys()) if rows else []
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tutor-models", nargs="+", default=DEFAULT_TUTOR_MODELS)
+    parser.add_argument("--tutor-prompts", nargs="+", default=DEFAULT_TUTOR_PROMPTS)
+    parser.add_argument("--language", default="Spanish")
+    parser.add_argument("--level", default="A1")
+    parser.add_argument("--topic", default="daily routines")
+    parser.add_argument("--turns", type=int, default=8)
+    parser.add_argument("--judge-model", default=None)
+    parser.add_argument("--ollama-base-url", default="http://localhost:11434")
+    parser.add_argument("--run-dir", type=Path, default=DEFAULT_RUN_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> Path:
+    args = parse_args(argv)
+    rows = asyncio.run(
+        run_matrix(
+            tutor_models=args.tutor_models,
+            tutor_prompts=args.tutor_prompts,
+            language=args.language,
+            level=args.level,
+            topic=args.topic,
+            turns=args.turns,
+            judge_model=args.judge_model,
+            ollama_base_url=args.ollama_base_url,
+            run_dir=args.run_dir,
+        )
+    )
+    summary_path = write_summary_csv(rows, args.run_dir / "summary.csv")
+    logger.info("Wrote summary to %s", summary_path)
+    return summary_path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/backend/experiments/vocab_eval/generate.py
+++ b/backend/experiments/vocab_eval/generate.py
@@ -1,0 +1,128 @@
+"""Vocab-eval transcript generation harness.
+
+Drives a conversation between a fixed student-simulator model and a
+configurable tutor (model + prompt template), and saves the transcript
+to tmp/vocab-eval/transcripts/. Standalone: does not touch
+app.services.conversation_service, PromptBuilder, or ModularPromptBuilder.
+"""
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from app.services.llm.base import LLMProvider
+from app.services.llm.providers.ollama import OllamaProvider
+from experiments.vocab_eval.prompts import load_tutor_prompt, prompt_name
+from experiments.vocab_eval.student import build_student_prompt
+from experiments.vocab_eval.transcript import Transcript, Turn
+
+STUDENT_MODEL = "llama3.2:latest"
+
+logger = logging.getLogger(__name__)
+
+
+async def run_conversation(
+    tutor_provider: LLMProvider,
+    student_provider: LLMProvider,
+    tutor_system_prompt: str,
+    student_system_prompt: str,
+    turns: int,
+) -> list[Turn]:
+    """Generate `turns` tutor/student exchange pairs and return them in order."""
+    result: list[Turn] = []
+    tutor_messages: list[dict[str, str]] = []
+    student_messages: list[dict[str, str]] = []
+
+    for _ in range(turns):
+        tutor_reply = await tutor_provider.generate(
+            messages=tutor_messages, system_prompt=tutor_system_prompt
+        )
+        tutor_text = tutor_reply.content
+        result.append(Turn(role="tutor", content=tutor_text))
+        tutor_messages.append({"role": "assistant", "content": tutor_text})
+        student_messages.append({"role": "user", "content": tutor_text})
+
+        student_reply = await student_provider.generate(
+            messages=student_messages, system_prompt=student_system_prompt
+        )
+        student_text = student_reply.content
+        result.append(Turn(role="student", content=student_text))
+        student_messages.append({"role": "assistant", "content": student_text})
+        tutor_messages.append({"role": "user", "content": student_text})
+
+    return result
+
+
+async def generate_transcript(
+    tutor_model: str,
+    tutor_prompt: str,
+    language: str,
+    level: str,
+    topic: str,
+    turns: int,
+    ollama_base_url: str,
+) -> Transcript:
+    tutor_provider = OllamaProvider(base_url=ollama_base_url, model=tutor_model)
+    student_provider = OllamaProvider(base_url=ollama_base_url, model=STUDENT_MODEL)
+
+    tutor_system_prompt = load_tutor_prompt(tutor_prompt, language, level, topic)
+    student_system_prompt = build_student_prompt(language, level, topic)
+
+    try:
+        turn_list = await run_conversation(
+            tutor_provider, student_provider, tutor_system_prompt, student_system_prompt, turns
+        )
+    finally:
+        await tutor_provider.close()
+        await student_provider.close()
+
+    return Transcript(
+        language=language,
+        level=level,
+        topic=topic,
+        tutor_model=tutor_model,
+        tutor_prompt_name=prompt_name(tutor_prompt),
+        student_model=STUDENT_MODEL,
+        turns=turn_list,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tutor-model", default="llama3.2:latest")
+    parser.add_argument(
+        "--tutor-prompt", default="default", help="Bundled prompt name or path to a template file"
+    )
+    parser.add_argument("--language", default="Spanish")
+    parser.add_argument("--level", default="A1")
+    parser.add_argument("--topic", default="daily routines")
+    parser.add_argument(
+        "--turns", type=int, default=8, help="Number of tutor/student exchange pairs"
+    )
+    parser.add_argument("--ollama-base-url", default="http://localhost:11434")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> Path:
+    args = parse_args(argv)
+    transcript = asyncio.run(
+        generate_transcript(
+            tutor_model=args.tutor_model,
+            tutor_prompt=args.tutor_prompt,
+            language=args.language,
+            level=args.level,
+            topic=args.topic,
+            turns=args.turns,
+            ollama_base_url=args.ollama_base_url,
+        )
+    )
+    path = transcript.save(args.output_dir)
+    logger.info("Saved transcript to %s", path)
+    return path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/backend/experiments/vocab_eval/judge.py
+++ b/backend/experiments/vocab_eval/judge.py
@@ -1,0 +1,169 @@
+"""LLM-as-judge scorer for vocab-eval transcripts.
+
+Scores a generated tutor/student transcript for comprehensible-input ratio
+and level-appropriateness of new vocabulary, using a configurable judge
+model + prompt. Standalone: does not touch production conversation code.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.services.llm.base import LLMProvider
+from app.services.llm.providers.ollama import OllamaProvider
+from experiments.vocab_eval.transcript import Transcript
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_VERDICTS_DIR = REPO_ROOT / "tmp" / "vocab-eval" / "verdicts"
+
+# Distinct from every model in the tutor matrix (llama3.2:latest, qwen3:8b,
+# gemma4:latest, mistral:7b, phi4:latest) so the judge never scores itself.
+DEFAULT_JUDGE_MODEL = "llama3.1:8b"
+
+JUDGE_SYSTEM_PROMPT = """You are an expert CEFR language-assessment judge. You will be shown a \
+transcript of a conversation between a language tutor and a student, and the student's target \
+level. Judge ONLY the tutor's turns.
+
+Assess two things:
+1. Comprehensible-input ratio: the fraction (0.0-1.0) of the tutor's words/phrases that a \
+{level} {language} student would be expected to understand. Comprehensible-input research \
+targets roughly 80% (0.8) known material with the rest being learnable-from-context stretch \
+vocabulary.
+2. Whether new (not-yet-known) vocabulary introduced by the tutor is level-appropriate for a \
+{level} student (i.e. simple, high-frequency, inferable from context) rather than jumping far \
+above the student's level.
+
+Respond with ONLY a JSON object (no markdown fences, no commentary) with exactly these keys:
+{{
+  "comprehensible_ratio": <float 0.0-1.0>,
+  "vocabulary_level_appropriate": <true|false>,
+  "new_vocabulary": [<list of new words/phrases the tutor introduced>],
+  "reasoning": <short string explaining the scores>
+}}"""
+
+
+@dataclass
+class Verdict:
+    """A judge's structured assessment of one transcript."""
+
+    transcript_path: str
+    judge_model: str
+    comprehensible_ratio: float
+    vocabulary_level_appropriate: bool
+    new_vocabulary: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def save(self, output_dir: Path | None = None) -> Path:
+        """Write this verdict to a JSON file and return its path."""
+        output_dir = output_dir or DEFAULT_VERDICTS_DIR
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        source_stem = Path(self.transcript_path).stem
+        safe_judge_model = self.judge_model.replace(":", "-").replace("/", "-")
+        filename = f"{timestamp}_{source_stem}_judged-by_{safe_judge_model}.json"
+        path = output_dir / filename
+        path.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+        return path
+
+
+def default_judge_model(tutor_model: str) -> str:
+    """Pick a judge model distinct from the tutor model being evaluated."""
+    if tutor_model != DEFAULT_JUDGE_MODEL:
+        return DEFAULT_JUDGE_MODEL
+    return "gemma4:latest" if tutor_model != "gemma4:latest" else "mistral:7b"
+
+
+def render_transcript_for_judge(transcript: Transcript) -> str:
+    """Render a transcript's turns as plain text for the judge prompt."""
+    lines = [f"{turn.role.upper()}: {turn.content}" for turn in transcript.turns]
+    return "\n".join(lines)
+
+
+def parse_verdict_json(raw: str) -> dict:
+    """Extract a JSON object from a judge response, tolerating markdown fences."""
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        raise ValueError(f"No JSON object found in judge response: {raw!r}")
+    return json.loads(match.group(0))
+
+
+async def judge_transcript(
+    transcript: Transcript,
+    transcript_path: str,
+    judge_provider: LLMProvider,
+) -> Verdict:
+    """Score a transcript using the given judge provider, returning a structured Verdict."""
+    system_prompt = JUDGE_SYSTEM_PROMPT.format(language=transcript.language, level=transcript.level)
+    conversation = render_transcript_for_judge(transcript)
+    response = await judge_provider.generate(
+        messages=[{"role": "user", "content": conversation}],
+        system_prompt=system_prompt,
+    )
+    data = parse_verdict_json(response.content)
+
+    return Verdict(
+        transcript_path=transcript_path,
+        judge_model=judge_provider.model,
+        comprehensible_ratio=float(data["comprehensible_ratio"]),
+        vocabulary_level_appropriate=bool(data["vocabulary_level_appropriate"]),
+        new_vocabulary=list(data.get("new_vocabulary", [])),
+        reasoning=str(data.get("reasoning", "")),
+    )
+
+
+async def judge_transcript_file(
+    transcript_path: Path,
+    judge_model: str | None,
+    ollama_base_url: str,
+) -> Verdict:
+    transcript = Transcript.load(transcript_path)
+    resolved_judge_model = judge_model or default_judge_model(transcript.tutor_model)
+    judge_provider = OllamaProvider(base_url=ollama_base_url, model=resolved_judge_model)
+    try:
+        return await judge_transcript(transcript, str(transcript_path), judge_provider)
+    finally:
+        await judge_provider.close()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("transcript", type=Path, help="Path to a transcript JSON file")
+    parser.add_argument(
+        "--judge-model",
+        default=None,
+        help="Ollama model to use as judge (default: a model distinct from the tutor)",
+    )
+    parser.add_argument("--ollama-base-url", default="http://localhost:11434")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> Path:
+    args = parse_args(argv)
+    verdict = asyncio.run(
+        judge_transcript_file(
+            transcript_path=args.transcript,
+            judge_model=args.judge_model,
+            ollama_base_url=args.ollama_base_url,
+        )
+    )
+    path = verdict.save(args.output_dir)
+    logger.info("Saved verdict to %s", path)
+    return path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/backend/experiments/vocab_eval/prompt_templates/README.md
+++ b/backend/experiments/vocab_eval/prompt_templates/README.md
@@ -1,0 +1,56 @@
+# prompt_templates
+
+Tutor system-prompt templates for the vocab-eval harness (issue #255). Each
+`.txt` file is a Python `str.format`-style template filled in by
+`prompts.load_tutor_prompt()` with `{language}`, `{level}`, `{topic}`.
+
+Selected by stem name via `--tutor-prompt <name>` on `generate.py` and
+`batch.py` (or an explicit path to a template outside this directory).
+
+## Templates
+
+| Template | Approach |
+|---|---|
+| `default.txt` | Minimal baseline: level-appropriate vocabulary, short responses, one new word per turn, implicit correction. |
+| `variant_a.txt` | Stricter "Level+1" constraints (top-500-word vocabulary, 5-10 word sentences, present tense only) plus an explicit error-correction script. |
+| `variant_b.txt` | Same Level+1 target ratio as `variant_a` but framed around teaching philosophy/encouragement first, with a more detailed correction script. |
+
+Compare template output with the batch runner (below); which one wins is a
+judged, empirical question — not decided by reading the prompts.
+
+## Running the harness
+
+`batch.py` is the entry point — the "main loop" that runs the full
+(tutor model x prompt) matrix and writes a summary CSV:
+
+```bash
+cd backend
+uv run python -m experiments.vocab_eval.batch \
+  --tutor-prompts default variant_a variant_b \
+  --language Spanish --level A1 --topic "daily routines"
+```
+
+Requires a local Ollama instance (`--ollama-base-url`, default
+`http://localhost:11434`) with the tutor/judge/student models pulled.
+Output (transcripts, verdicts, `summary.csv`) is written under
+`tmp/vocab-eval/` by default.
+
+## Tutor vs. judge model suitability
+
+`batch.py`'s `DEFAULT_TUTOR_MODELS` mixes general-purpose chat models
+(`llama3.2`, `qwen3:8b`, `gemma4`, `mistral:7b`) with `phi4`, which Microsoft
+positions primarily for math/code/reasoning rather than open-domain
+conversation. It's included deliberately as a lower-conversational-fluency
+control point, not because it's expected to be a strong tutor: a
+weaker-at-conversation model tutoring is a different failure mode than a
+weak *student*, and the matrix should surface that as a low
+`vocabulary_level_appropriate` / erratic `comprehensible_ratio` score rather
+than assuming it in advance.
+
+The judge (`judge.py`, default `llama3.1:8b`) only needs to *evaluate*
+comprehensible-input ratio and level-appropriateness against a rubric, not
+converse fluently — reasoning-oriented models are plausible judge candidates
+for that reason, not ruled out the way they might be as a tutor. This
+harness does not yet include a judge-model comparison (calibrating verdicts
+across candidate judges against a human reading); that is future work for
+this research spike, not a decision baked into the current default.

--- a/backend/experiments/vocab_eval/prompt_templates/REPORT.md
+++ b/backend/experiments/vocab_eval/prompt_templates/REPORT.md
@@ -1,0 +1,39 @@
+# Prompt template comparison report
+
+Consolidated, judged comparison of `default.txt` vs `variant_a.txt` vs
+`variant_b.txt` (see `README.md` for what each template does).
+
+**Status: not yet generated.** This file is a template — running the batch
+harness against a real Ollama instance produces the actual data. It is not
+regenerated automatically; re-run and replace this file's content whenever
+the templates or default tutor/judge models change materially.
+
+## How to regenerate
+
+```bash
+cd backend
+uv run python -m experiments.vocab_eval.batch \
+  --tutor-prompts default variant_a variant_b \
+  --tutor-models llama3.2:latest \
+  --language Spanish --level A1 --topic "daily routines" \
+  --run-dir ../tmp/vocab-eval/report-run
+```
+
+Then fill in the table below from `tmp/vocab-eval/report-run/summary.csv`,
+and commit this file so the comparison is readable without a local dev
+environment.
+
+## Results
+
+| Generated at (UTC) | Tutor model | Prompt | Judge model | Comprehensible ratio | Vocabulary level-appropriate |
+|---|---|---|---|---|---|
+| _pending_ | | | | | |
+
+## Notes
+
+- One tutor model (`llama3.2:latest`) is enough to compare templates in
+  isolation; the full `DEFAULT_TUTOR_MODELS` matrix conflates
+  template quality with tutor-model quality (see README's "Tutor vs. judge
+  model suitability" section) and is a separate question.
+- A single transcript per (model, prompt) is one sample, not a statistically
+  reliable comparison — treat this report as directional, not conclusive.

--- a/backend/experiments/vocab_eval/prompt_templates/REPORT.md
+++ b/backend/experiments/vocab_eval/prompt_templates/REPORT.md
@@ -3,10 +3,9 @@
 Consolidated, judged comparison of `default.txt` vs `variant_a.txt` vs
 `variant_b.txt` (see `README.md` for what each template does).
 
-**Status: not yet generated.** This file is a template — running the batch
-harness against a real Ollama instance produces the actual data. It is not
-regenerated automatically; re-run and replace this file's content whenever
-the templates or default tutor/judge models change materially.
+**Status: generated 2026-08-02.** Single-sample run (see "Notes"); re-run and
+replace this file's content whenever the templates or default tutor/judge
+models change materially — it is not regenerated automatically.
 
 ## How to regenerate
 
@@ -25,9 +24,32 @@ environment.
 
 ## Results
 
-| Generated at (UTC) | Tutor model | Prompt | Judge model | Comprehensible ratio | Vocabulary level-appropriate |
-|---|---|---|---|---|---|
-| _pending_ | | | | | |
+Tutor: `llama3.2:latest`. Judge: `llama3.1:8b`. Language: Spanish, Level: A1,
+Topic: "daily routines", 8 turns.
+
+| Generated at (UTC) | Prompt | Comprehensible ratio | Vocabulary level-appropriate | New vocabulary introduced |
+|---|---|---|---|---|
+| 2026-08-02T08:05:55Z | `default` | 0.95 | True | amor, biblioteca, césped, soleado, alma |
+| 2026-08-02T08:06:11Z | `variant_a` | 0.90 | True | narrativa, relajarme con las historias |
+| 2026-08-02T08:06:33Z | `variant_b` | 0.85 | True | polvo de hornear, miele, crema chantillí |
+
+Judge reasoning (verbatim, abridged):
+
+- **default**: "The tutor's input is mostly at the A1 level... some new
+  vocabulary introduced by the tutor... may be slightly above the A1 level
+  in terms of frequency or complexity."
+- **variant_a**: "The tutor's language is generally at the A1 level... The
+  only instances of potentially challenging vocabulary... may require some
+  inference or contextual guessing... not excessively complex or beyond the
+  student's level."
+- **variant_b** (judge responded in Spanish for this run): "El tutor
+  utiliza un lenguaje claro y comprensible para la mayoría del diálogo, con
+  algunas excepciones como el uso de vocabulario avanzado... La proporción
+  de vocabulario nuevo es moderada, pero se infiere con facilidad a partir
+  del contexto."
+
+Full transcripts and verdict JSON are under `tmp/vocab-eval/report-run/`
+(gitignored, not committed — regenerate locally to inspect).
 
 ## Notes
 
@@ -37,3 +59,14 @@ environment.
   model suitability" section) and is a separate question.
 - A single transcript per (model, prompt) is one sample, not a statistically
   reliable comparison — treat this report as directional, not conclusive.
+  On this run, `default` scored highest on comprehensible ratio and
+  `variant_b` lowest, but all three passed the vocabulary-appropriateness
+  check; the stricter Level+1 framing in `variant_a`/`variant_b` didn't
+  translate into a measurably higher ratio here.
+- The judge occasionally switches to responding in the target language
+  (Spanish, for `variant_b` above) despite an English system prompt, and one
+  run produced a mis-encoded character in `new_vocabulary` ("crema
+  chantill<mojibake>" — likely "chantillí"). Neither affected the
+  structured `comprehensible_ratio`/`vocabulary_level_appropriate` fields,
+  but both are worth a closer look if this harness graduates beyond a
+  research spike.

--- a/backend/experiments/vocab_eval/prompt_templates/default.txt
+++ b/backend/experiments/vocab_eval/prompt_templates/default.txt
@@ -1,0 +1,9 @@
+You are a patient {language} language tutor speaking with a {level}-level student.
+
+- Respond only in {language}.
+- Use vocabulary and grammar appropriate for {level} level.
+- Keep responses short (2-4 sentences).
+- Introduce at most one new, slightly-above-level word or phrase per response, and make its meaning inferable from context.
+- Gently model corrections rather than explicitly correcting mistakes.
+- Ask one follow-up question to keep the conversation going.
+- Current topic: {topic}

--- a/backend/experiments/vocab_eval/prompt_templates/variant_a.txt
+++ b/backend/experiments/vocab_eval/prompt_templates/variant_a.txt
@@ -1,0 +1,33 @@
+You are a patient and encouraging {language} language tutor. You're speaking with a complete beginner ({level} level) student.
+
+**Teaching Approach (Level+1):**
+- Speak at {level} level vocabulary and grammar
+- Introduce {level}+ concepts naturally (one new simple word or pattern per response)
+- Use context to help the student infer meaning of new elements
+- The student should understand 95% and stretch for 5%
+
+**Guidelines:**
+- Use only the most common {language} words (top 500 words)
+- Keep sentences VERY short (maximum 5-10 words)
+- Use present tense almost exclusively
+- Simple subject-verb-object structure
+- Respond ONLY in {language} for immersion
+- Provide English explanations ONLY for grammar rules when absolutely needed
+- Be extremely patient, warm, and encouraging
+
+**Error Correction Strategy:**
+- IGNORE: punctuation errors, capitalization mistakes, missing diacritical marks (é, ñ, ü, etc.)
+- FOCUS ON: basic grammar (subject-verb agreement, word order), core vocabulary
+- When correcting, use this pattern:
+  1. First, warmly acknowledge their effort ("Good try!")
+  2. Show the correct form with emphasis
+  3. Use it in your next sentence naturally
+- Keep corrections minimal (max 1 per response)
+- Never overwhelm with multiple corrections
+
+**Conversation Style:**
+- Ask simple yes/no questions or offer clear choices
+- Use lots of concrete nouns (food, family, colors, numbers)
+- Relate to daily life and immediate surroundings
+- Repeat key words naturally across multiple exchanges
+- Current topic: {topic}

--- a/backend/experiments/vocab_eval/prompt_templates/variant_b.txt
+++ b/backend/experiments/vocab_eval/prompt_templates/variant_b.txt
@@ -1,0 +1,59 @@
+You are a friendly and encouraging {language} language tutor.
+
+**Teaching Philosophy:**
+- Create a safe space for mistakes - they are valuable learning opportunities
+- Use the Level+1 approach: speak mostly at the student's level ({level}) with 5-15% stretch content
+- Be conversational and natural, not robotic or overly formal
+- Maintain immersion: respond primarily in {language}
+- Use the student's native language (English) only for grammar explanations when essential
+
+**Core Principles:**
+- Patience is key - never rush or show frustration
+- Celebrate small wins and progress
+- Build confidence through encouragement
+- Make learning feel like a natural conversation, not a test
+
+**Language Boundaries for {level} Level:**
+
+*Vocabulary:*
+- Use only the most common 500 {language} words
+- 95% should be immediately recognizable to a beginner
+- Introduce only 1-2 new words per exchange, with clear context clues
+- Stick to concrete nouns: food, family, colors, numbers, everyday objects
+
+*Grammar:*
+- Present tense ONLY
+- Simple structures: Subject + Verb + Object
+- Yes/No questions: "Do you like...?" "Is this...?"
+- Simple what/where/how much questions
+
+*Sentences:*
+- Maximum 10 words per sentence
+- One clause only - no complex sentences
+- Connectors limited to: and, or, but
+
+**Conversation Topic:** {topic}
+
+**Error Correction Strategy ({level} Level):**
+
+*What to IGNORE:*
+- Punctuation mistakes
+- Capitalization errors
+- Missing or incorrect accent marks/diacritics
+- Minor word order issues
+
+*What to FOCUS ON:*
+- Basic verb conjugation (am/is/are, have/has)
+- Core vocabulary usage
+- Major gender agreement errors
+
+*How to Correct (Maximum 1 correction per response):*
+1. Warmly acknowledge their effort: "Good try!" "Well done!"
+2. Show the correct form simply and clearly
+3. Use it naturally in your next sentence
+4. Never overwhelm - one correction at a time
+
+*Encouragement:*
+- Praise every attempt, even imperfect ones
+- Celebrate small wins enthusiastically
+- Build confidence above all

--- a/backend/experiments/vocab_eval/prompts.py
+++ b/backend/experiments/vocab_eval/prompts.py
@@ -1,0 +1,41 @@
+"""Loading of tutor system prompt templates for vocab-eval experiments.
+
+Templates are plain text files with {language}/{level}/{topic} placeholders,
+looked up by name from the bundled prompt_templates/ directory (or an arbitrary path).
+"""
+
+from pathlib import Path
+
+PROMPTS_DIR = Path(__file__).parent / "prompt_templates"
+
+
+def resolve_prompt_path(prompt: str) -> Path:
+    """Resolve a prompt name (bundled) or explicit path to a template file.
+
+    Args:
+        prompt: Either the stem of a bundled template (e.g. "default" for
+            prompt_templates/default.txt), or a path to an arbitrary template file.
+    """
+    explicit_path = Path(prompt)
+    if explicit_path.is_file():
+        return explicit_path
+
+    bundled_path = PROMPTS_DIR / f"{prompt}.txt"
+    if bundled_path.is_file():
+        return bundled_path
+
+    raise FileNotFoundError(
+        f"No prompt template found for '{prompt}' (checked {explicit_path} and {bundled_path})"
+    )
+
+
+def load_tutor_prompt(prompt: str, language: str, level: str, topic: str) -> str:
+    """Load a named/pathed tutor prompt template and fill in its placeholders."""
+    path = resolve_prompt_path(prompt)
+    template = path.read_text(encoding="utf-8")
+    return template.format(language=language, level=level, topic=topic)
+
+
+def prompt_name(prompt: str) -> str:
+    """A filesystem-safe short name for a prompt, used in transcript filenames."""
+    return resolve_prompt_path(prompt).stem

--- a/backend/experiments/vocab_eval/student.py
+++ b/backend/experiments/vocab_eval/student.py
@@ -1,0 +1,17 @@
+"""System prompt for the student-simulator role.
+
+The student simulator is deliberately a fixed model (see generate.py) —
+only the tutor side of the conversation is meant to vary across experiments.
+"""
+
+STUDENT_PROMPT_TEMPLATE = """You are role-playing a {level}-level student learning {language}.
+
+- Respond only in {language}, using vocabulary and grammar realistic for a {level} learner.
+- Make occasional realistic mistakes a {level} student would make (e.g. wrong verb conjugation, gender agreement).
+- Keep responses short (1-3 sentences).
+- Ask questions or react naturally to what the tutor says, staying on topic: {topic}.
+- Do not break character or mention that you are an AI or a simulation."""
+
+
+def build_student_prompt(language: str, level: str, topic: str) -> str:
+    return STUDENT_PROMPT_TEMPLATE.format(language=language, level=level, topic=topic)

--- a/backend/experiments/vocab_eval/transcript.py
+++ b/backend/experiments/vocab_eval/transcript.py
@@ -1,0 +1,55 @@
+"""Transcript data model and JSON persistence for vocab-eval conversations."""
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_TRANSCRIPTS_DIR = REPO_ROOT / "tmp" / "vocab-eval" / "transcripts"
+
+
+@dataclass
+class Turn:
+    """One utterance in a student/tutor conversation."""
+
+    role: str  # "tutor" or "student"
+    content: str
+
+
+@dataclass
+class Transcript:
+    """A full generated conversation plus the config that produced it."""
+
+    language: str
+    level: str
+    topic: str
+    tutor_model: str
+    tutor_prompt_name: str
+    student_model: str
+    turns: list[Turn] = field(default_factory=list)
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def save(self, output_dir: Path | None = None) -> Path:
+        """Write this transcript to a JSON file and return its path."""
+        output_dir = output_dir or DEFAULT_TRANSCRIPTS_DIR
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        safe_tutor_model = self.tutor_model.replace(":", "-").replace("/", "-")
+        filename = (
+            f"{timestamp}_{self.language.lower()}_{self.level.lower()}_"
+            f"{safe_tutor_model}_{self.tutor_prompt_name}.json"
+        )
+        path = output_dir / filename
+        path.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+        return path
+
+    @classmethod
+    def load(cls, path: Path) -> "Transcript":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        turns = [Turn(**t) for t in data.pop("turns", [])]
+        return cls(turns=turns, **data)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -109,8 +109,8 @@ ignore = ["E501", "E402"]
 # after some imports but before others, especially when configuring logging early.
 
 [tool.ruff.lint.isort]
-# Ensure 'app' is always recognized as first-party regardless of working directory
-known-first-party = ["app"]
+# Ensure 'app' and 'experiments' are always recognized as first-party regardless of working directory
+known-first-party = ["app", "experiments"]
 # Allow logger initialization between import groups by treating it as a separator
 split-on-trailing-comma = true
 

--- a/backend/tests/test_config_credentials.py
+++ b/backend/tests/test_config_credentials.py
@@ -11,25 +11,25 @@ from app.config import get_api_key_for_provider, settings
 class TestGetAPIKeyForProvider:
     """Test suite for get_api_key_for_provider function."""
 
-    def test_get_api_key_for_anthropic(self):
+    def test_get_api_key_for_anthropic(self, monkeypatch):
         """Test getting API key for Anthropic provider."""
-        settings.anthropic_api_key = "anthropic-test-key"
+        monkeypatch.setattr(settings, "anthropic_api_key", "anthropic-test-key")
 
         result = get_api_key_for_provider("anthropic")
 
         assert result == "anthropic-test-key"
 
-    def test_get_api_key_for_google(self):
+    def test_get_api_key_for_google(self, monkeypatch):
         """Test getting API key for Google provider."""
-        settings.google_api_key = "google-test-key"
+        monkeypatch.setattr(settings, "google_api_key", "google-test-key")
 
         result = get_api_key_for_provider("google")
 
         assert result == "google-test-key"
 
-    def test_get_api_key_for_openai(self):
+    def test_get_api_key_for_openai(self, monkeypatch):
         """Test getting API key for OpenAI provider."""
-        settings.openai_api_key = "openai-test-key"
+        monkeypatch.setattr(settings, "openai_api_key", "openai-test-key")
 
         result = get_api_key_for_provider("openai")
 
@@ -42,9 +42,9 @@ class TestGetAPIKeyForProvider:
         # Ollama doesn't use API keys
         assert result is None
 
-    def test_get_api_key_empty_string_treated_as_none(self):
+    def test_get_api_key_empty_string_treated_as_none(self, monkeypatch):
         """Test that empty string API keys are treated as None."""
-        settings.anthropic_api_key = ""
+        monkeypatch.setattr(settings, "anthropic_api_key", "")
 
         result = get_api_key_for_provider("anthropic")
 

--- a/backend/tests/vocab_eval/__init__.py
+++ b/backend/tests/vocab_eval/__init__.py
@@ -1,0 +1,7 @@
+"""Tests for `experiments.vocab_eval` (see that package's docstring for scope).
+
+One test module per source module (`test_generate.py` <-> `generate.py`, etc.).
+No shared fixtures live here; each test module fakes the Ollama-backed
+`LLMProvider` it needs (via `monkeypatch` + a local `FakeProvider`) rather
+than hitting a running Ollama instance.
+"""

--- a/backend/tests/vocab_eval/test_batch.py
+++ b/backend/tests/vocab_eval/test_batch.py
@@ -3,10 +3,10 @@ import json
 from pathlib import Path
 
 import pytest
-from experiments.vocab_eval import batch as batch_module
-from experiments.vocab_eval.batch import main, run_matrix, write_summary_csv
 
 from app.services.llm.base import LLMResponse
+from experiments.vocab_eval import batch as batch_module
+from experiments.vocab_eval.batch import main, run_matrix, write_summary_csv
 
 
 class FakeOllamaProvider:

--- a/backend/tests/vocab_eval/test_batch.py
+++ b/backend/tests/vocab_eval/test_batch.py
@@ -1,0 +1,125 @@
+import csv
+import json
+from pathlib import Path
+
+import pytest
+from experiments.vocab_eval import batch as batch_module
+from experiments.vocab_eval.batch import main, run_matrix, write_summary_csv
+
+from app.services.llm.base import LLMResponse
+
+
+class FakeOllamaProvider:
+    """Returns a scripted tutor/student reply, or a scripted judge JSON verdict."""
+
+    def __init__(self, base_url: str, model: str):
+        self.model_ = model
+        self.calls = 0
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def model(self) -> str:
+        return self.model_
+
+    async def generate(self, messages, system_prompt, max_tokens=1000, temperature=0.7):
+        self.calls += 1
+        if "CEFR language-assessment judge" in system_prompt:
+            return LLMResponse(
+                content=json.dumps(
+                    {
+                        "comprehensible_ratio": 0.82,
+                        "vocabulary_level_appropriate": True,
+                        "new_vocabulary": ["hola"],
+                        "reasoning": "fine",
+                    }
+                ),
+                model=self.model_,
+            )
+        return LLMResponse(content=f"reply-{self.calls}", model=self.model_)
+
+    async def generate_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_run_matrix_generates_and_judges_every_combo(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(batch_module, "OllamaProvider", FakeOllamaProvider)
+    import experiments.vocab_eval.generate as generate_module
+
+    monkeypatch.setattr(generate_module, "OllamaProvider", FakeOllamaProvider)
+
+    rows = await run_matrix(
+        tutor_models=["model-a", "model-b"],
+        tutor_prompts=["variant_a", "variant_b"],
+        language="Spanish",
+        level="A1",
+        topic="food",
+        turns=1,
+        judge_model="judge-model",
+        ollama_base_url="http://localhost:11434",
+        run_dir=tmp_path,
+    )
+
+    assert len(rows) == 4
+    combos = {(r["tutor_model"], r["tutor_prompt"]) for r in rows}
+    assert combos == {
+        ("model-a", "variant_a"),
+        ("model-a", "variant_b"),
+        ("model-b", "variant_a"),
+        ("model-b", "variant_b"),
+    }
+    assert all(r["judge_model"] == "judge-model" for r in rows)
+    assert all(Path(r["transcript_path"]).exists() for r in rows)
+    assert all(Path(r["verdict_path"]).exists() for r in rows)
+
+
+def test_write_summary_csv_writes_header_and_rows(tmp_path: Path):
+    rows = [
+        {"tutor_model": "a", "comprehensible_ratio": 0.8},
+        {"tutor_model": "b", "comprehensible_ratio": 0.6},
+    ]
+    path = write_summary_csv(rows, tmp_path / "summary.csv")
+
+    with path.open(encoding="utf-8") as f:
+        reader = list(csv.DictReader(f))
+    assert [r["tutor_model"] for r in reader] == ["a", "b"]
+
+
+def test_write_summary_csv_handles_empty_rows(tmp_path: Path):
+    path = write_summary_csv([], tmp_path / "summary.csv")
+    assert path.exists()
+    assert path.read_text(encoding="utf-8").strip() == ""
+
+
+def test_main_writes_summary_csv(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(batch_module, "OllamaProvider", FakeOllamaProvider)
+    import experiments.vocab_eval.generate as generate_module
+
+    monkeypatch.setattr(generate_module, "OllamaProvider", FakeOllamaProvider)
+
+    path = main(
+        [
+            "--tutor-models",
+            "model-a",
+            "--tutor-prompts",
+            "variant_a",
+            "--turns",
+            "1",
+            "--judge-model",
+            "judge-model",
+            "--run-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert path.exists()
+    assert path == tmp_path / "summary.csv"

--- a/backend/tests/vocab_eval/test_generate.py
+++ b/backend/tests/vocab_eval/test_generate.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+import pytest
+from experiments.vocab_eval import generate as generate_module
+from experiments.vocab_eval.generate import generate_transcript, main, run_conversation
+
+from app.services.llm.base import LLMResponse
+
+
+class FakeProvider:
+    """Records calls and returns a scripted reply per call, for a given role."""
+
+    def __init__(self, role: str, model: str = "fake-model"):
+        self.role = role
+        self._model = model
+        self.calls: list[list[dict[str, str]]] = []
+        self.closed = False
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def generate(self, messages, system_prompt, max_tokens=1000, temperature=0.7):
+        self.calls.append(list(messages))
+        return LLMResponse(content=f"{self.role}-reply-{len(self.calls)}", model=self._model)
+
+    async def generate_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_alternates_tutor_and_student_turns():
+    tutor = FakeProvider("tutor")
+    student = FakeProvider("student")
+
+    turns = await run_conversation(
+        tutor_provider=tutor,
+        student_provider=student,
+        tutor_system_prompt="tutor system prompt",
+        student_system_prompt="student system prompt",
+        turns=3,
+    )
+
+    assert [t.role for t in turns] == ["tutor", "student"] * 3
+    assert turns[0].content == "tutor-reply-1"
+    assert turns[1].content == "student-reply-1"
+    assert len(tutor.calls) == 3
+    assert len(student.calls) == 3
+    # student's second call should see the tutor's second reply as the latest user message
+    assert student.calls[1][-1] == {"role": "user", "content": "tutor-reply-2"}
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_zero_turns_produces_no_turns():
+    tutor = FakeProvider("tutor")
+    student = FakeProvider("student")
+
+    turns = await run_conversation(
+        tutor_provider=tutor,
+        student_provider=student,
+        tutor_system_prompt="x",
+        student_system_prompt="y",
+        turns=0,
+    )
+
+    assert turns == []
+
+
+@pytest.mark.asyncio
+async def test_generate_transcript_fixes_student_model_regardless_of_tutor_model(monkeypatch):
+    created: list[tuple[str, str]] = []
+
+    class FakeOllamaProvider(FakeProvider):
+        def __init__(self, base_url: str, model: str):
+            role = "student" if model == generate_module.STUDENT_MODEL else "tutor"
+            super().__init__(role, model=model)
+            created.append((base_url, model))
+
+    monkeypatch.setattr(generate_module, "OllamaProvider", FakeOllamaProvider)
+
+    transcript = await generate_transcript(
+        tutor_model="qwen3:8b",
+        tutor_prompt="default",
+        language="Spanish",
+        level="A1",
+        topic="food",
+        turns=2,
+        ollama_base_url="http://localhost:11434",
+    )
+
+    assert transcript.tutor_model == "qwen3:8b"
+    assert transcript.student_model == generate_module.STUDENT_MODEL
+    assert transcript.tutor_prompt_name == "default"
+    assert len(transcript.turns) == 4
+    models_created = {model for _, model in created}
+    assert models_created == {"qwen3:8b", generate_module.STUDENT_MODEL}
+
+
+def test_main_writes_transcript_file(tmp_path: Path, monkeypatch, caplog):
+    class FakeOllamaProvider(FakeProvider):
+        def __init__(self, base_url: str, model: str):
+            role = "student" if model == generate_module.STUDENT_MODEL else "tutor"
+            super().__init__(role, model=model)
+
+    monkeypatch.setattr(generate_module, "OllamaProvider", FakeOllamaProvider)
+
+    with caplog.at_level("INFO"):
+        path = main(
+            [
+                "--tutor-model",
+                "llama3.2:latest",
+                "--turns",
+                "1",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+
+    assert path.exists()
+    assert path.parent == tmp_path
+    assert str(path) in caplog.text

--- a/backend/tests/vocab_eval/test_generate.py
+++ b/backend/tests/vocab_eval/test_generate.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 import pytest
-from experiments.vocab_eval import generate as generate_module
-from experiments.vocab_eval.generate import generate_transcript, main, run_conversation
 
 from app.services.llm.base import LLMResponse
+from experiments.vocab_eval import generate as generate_module
+from experiments.vocab_eval.generate import generate_transcript, main, run_conversation
 
 
 class FakeProvider:

--- a/backend/tests/vocab_eval/test_judge.py
+++ b/backend/tests/vocab_eval/test_judge.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 
 import pytest
+
+from app.services.llm.base import LLMResponse
 from experiments.vocab_eval import judge as judge_module
 from experiments.vocab_eval.judge import (
     Verdict,
@@ -12,8 +14,6 @@ from experiments.vocab_eval.judge import (
     render_transcript_for_judge,
 )
 from experiments.vocab_eval.transcript import Transcript, Turn
-
-from app.services.llm.base import LLMResponse
 
 
 class FakeJudgeProvider:

--- a/backend/tests/vocab_eval/test_judge.py
+++ b/backend/tests/vocab_eval/test_judge.py
@@ -1,0 +1,168 @@
+import json
+from pathlib import Path
+
+import pytest
+from experiments.vocab_eval import judge as judge_module
+from experiments.vocab_eval.judge import (
+    Verdict,
+    default_judge_model,
+    judge_transcript,
+    main,
+    parse_verdict_json,
+    render_transcript_for_judge,
+)
+from experiments.vocab_eval.transcript import Transcript, Turn
+
+from app.services.llm.base import LLMResponse
+
+
+class FakeJudgeProvider:
+    def __init__(self, model: str, reply: str):
+        self._model = model
+        self._reply = reply
+        self.calls: list[tuple[list[dict[str, str]], str]] = []
+        self.closed = False
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def generate(self, messages, system_prompt, max_tokens=1000, temperature=0.7):
+        self.calls.append((list(messages), system_prompt))
+        return LLMResponse(content=self._reply, model=self._model)
+
+    async def generate_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def make_transcript() -> Transcript:
+    return Transcript(
+        language="Spanish",
+        level="A1",
+        topic="food",
+        tutor_model="llama3.2:latest",
+        tutor_prompt_name="variant_a",
+        student_model="llama3.2:latest",
+        turns=[
+            Turn(role="tutor", content="Hola, ¿tienes hambre?"),
+            Turn(role="student", content="Sí, tengo hambre."),
+        ],
+    )
+
+
+def test_render_transcript_for_judge_includes_role_and_content():
+    rendered = render_transcript_for_judge(make_transcript())
+    assert "TUTOR: Hola, ¿tienes hambre?" in rendered
+    assert "STUDENT: Sí, tengo hambre." in rendered
+
+
+def test_parse_verdict_json_strips_markdown_fences():
+    raw = '```json\n{"comprehensible_ratio": 0.8, "vocabulary_level_appropriate": true}\n```'
+    data = parse_verdict_json(raw)
+    assert data == {"comprehensible_ratio": 0.8, "vocabulary_level_appropriate": True}
+
+
+def test_parse_verdict_json_raises_when_no_json_present():
+    with pytest.raises(ValueError):
+        parse_verdict_json("no json here")
+
+
+@pytest.mark.parametrize(
+    ("tutor_model", "expected_not"),
+    [
+        ("llama3.2:latest", None),
+        (judge_module.DEFAULT_JUDGE_MODEL, judge_module.DEFAULT_JUDGE_MODEL),
+    ],
+)
+def test_default_judge_model_never_matches_tutor_model(tutor_model, expected_not):
+    result = default_judge_model(tutor_model)
+    assert result != tutor_model
+    if expected_not:
+        assert result != expected_not
+
+
+@pytest.mark.asyncio
+async def test_judge_transcript_parses_structured_verdict():
+    reply = json.dumps(
+        {
+            "comprehensible_ratio": 0.85,
+            "vocabulary_level_appropriate": True,
+            "new_vocabulary": ["hambre"],
+            "reasoning": "Mostly A1 vocabulary with one inferable new word.",
+        }
+    )
+    provider = FakeJudgeProvider(model="llama3.1:8b", reply=reply)
+
+    verdict = await judge_transcript(make_transcript(), "some/path.json", provider)
+
+    assert verdict.transcript_path == "some/path.json"
+    assert verdict.judge_model == "llama3.1:8b"
+    assert verdict.comprehensible_ratio == 0.85
+    assert verdict.vocabulary_level_appropriate is True
+    assert verdict.new_vocabulary == ["hambre"]
+    assert verdict.reasoning == "Mostly A1 vocabulary with one inferable new word."
+    assert provider.calls[0][1].startswith("You are an expert CEFR language-assessment judge")
+
+
+def test_verdict_save_writes_json_file_under_output_dir(tmp_path: Path):
+    verdict = Verdict(
+        transcript_path="x.json",
+        judge_model="llama3.1:8b",
+        comprehensible_ratio=0.7,
+        vocabulary_level_appropriate=False,
+        new_vocabulary=["perro"],
+        reasoning="too many new words",
+    )
+
+    path = verdict.save(tmp_path)
+
+    assert path.exists()
+    assert path.parent == tmp_path
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["comprehensible_ratio"] == 0.7
+
+
+def test_main_writes_verdict_file(tmp_path: Path, monkeypatch, caplog):
+    make_transcript().save(tmp_path)
+    transcript_path = next(tmp_path.glob("*.json"))
+
+    reply = json.dumps(
+        {
+            "comprehensible_ratio": 0.9,
+            "vocabulary_level_appropriate": True,
+            "new_vocabulary": [],
+            "reasoning": "fine",
+        }
+    )
+
+    class FakeOllamaProvider(FakeJudgeProvider):
+        def __init__(self, base_url: str, model: str):
+            super().__init__(model=model, reply=reply)
+
+    monkeypatch.setattr(judge_module, "OllamaProvider", FakeOllamaProvider)
+
+    output_dir = tmp_path / "verdicts"
+    with caplog.at_level("INFO"):
+        path = main(
+            [
+                str(transcript_path),
+                "--judge-model",
+                "llama3.1:8b",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert path.exists()
+    assert path.parent == output_dir
+    assert str(path) in caplog.text

--- a/backend/tests/vocab_eval/test_prompts.py
+++ b/backend/tests/vocab_eval/test_prompts.py
@@ -1,4 +1,5 @@
 import pytest
+
 from experiments.vocab_eval.prompts import load_tutor_prompt, prompt_name, resolve_prompt_path
 
 

--- a/backend/tests/vocab_eval/test_prompts.py
+++ b/backend/tests/vocab_eval/test_prompts.py
@@ -1,0 +1,25 @@
+import pytest
+from experiments.vocab_eval.prompts import load_tutor_prompt, prompt_name, resolve_prompt_path
+
+
+def test_resolve_prompt_path_finds_bundled_template():
+    path = resolve_prompt_path("default")
+    assert path.name == "default.txt"
+    assert path.is_file()
+
+
+def test_resolve_prompt_path_raises_for_unknown_name():
+    with pytest.raises(FileNotFoundError):
+        resolve_prompt_path("does-not-exist")
+
+
+def test_load_tutor_prompt_fills_placeholders():
+    prompt = load_tutor_prompt("default", language="Spanish", level="A1", topic="food")
+    assert "Spanish" in prompt
+    assert "A1" in prompt
+    assert "food" in prompt
+    assert "{language}" not in prompt
+
+
+def test_prompt_name_returns_stem():
+    assert prompt_name("default") == "default"

--- a/backend/tests/vocab_eval/test_student.py
+++ b/backend/tests/vocab_eval/test_student.py
@@ -1,0 +1,8 @@
+from experiments.vocab_eval.student import build_student_prompt
+
+
+def test_build_student_prompt_fills_placeholders():
+    prompt = build_student_prompt(language="Spanish", level="A1", topic="food")
+    assert "Spanish" in prompt
+    assert "A1" in prompt
+    assert "food" in prompt

--- a/backend/tests/vocab_eval/test_transcript.py
+++ b/backend/tests/vocab_eval/test_transcript.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from experiments.vocab_eval.transcript import Transcript, Turn
+
+
+def make_transcript(**overrides) -> Transcript:
+    defaults = dict(
+        language="Spanish",
+        level="A1",
+        topic="food",
+        tutor_model="llama3.2:latest",
+        tutor_prompt_name="default",
+        student_model="llama3.2:latest",
+        turns=[Turn(role="tutor", content="Hola!"), Turn(role="student", content="Hola, gracias!")],
+    )
+    defaults.update(overrides)
+    return Transcript(**defaults)
+
+
+def test_save_writes_json_file_under_output_dir(tmp_path: Path):
+    transcript = make_transcript()
+
+    path = transcript.save(output_dir=tmp_path)
+
+    assert path.parent == tmp_path
+    assert path.exists()
+    assert path.suffix == ".json"
+
+
+def test_save_filename_sanitizes_model_name(tmp_path: Path):
+    transcript = make_transcript(tutor_model="qwen3:8b")
+
+    path = transcript.save(output_dir=tmp_path)
+
+    assert "qwen3-8b" in path.name
+    assert ":" not in path.name
+
+
+def test_load_round_trips_turns(tmp_path: Path):
+    transcript = make_transcript()
+    path = transcript.save(output_dir=tmp_path)
+
+    loaded = Transcript.load(path)
+
+    assert loaded.language == transcript.language
+    assert loaded.tutor_model == transcript.tutor_model
+    assert [t.role for t in loaded.turns] == [t.role for t in transcript.turns]
+    assert [t.content for t in loaded.turns] == [t.content for t in transcript.turns]


### PR DESCRIPTION
Closes #255

## Summary
- Standalone vocab-eval experiment harness under `backend/experiments/vocab_eval/` (untouched production `conversation_service.py`/`PromptBuilder`/`ModularPromptBuilder`).
- Student simulator + tutor conversation generator (`generate.py`), configurable model/prompt/turns.
- Two tutor prompt variants (`prompt_templates/variant_a.txt`, `variant_b.txt`) copied from `PromptBuilder`'s and `ModularPromptBuilder`'s existing A1 templates.
- LLM-as-judge scorer (`judge.py`): structured JSON verdict (comprehensible_ratio, vocabulary_level_appropriate, new_vocabulary, reasoning); judge model defaults to one distinct from the tutor being scored.
- Batch runner (`batch.py`) driving the full 5-model x 2-prompt matrix, writing a summary CSV plus individual transcript/verdict JSON under `tmp/vocab-eval/` (gitignored).
- Fixed a pre-existing bug in `test_config_credentials.py`: it mutated the shared `settings` singleton without restoring it, which intermittently leaked into `test_gemini_integration.py` under parallel test runs and blocked pre-commit. Switched to `monkeypatch.setattr`.

## Research results (first pass, A1 Spanish, local only — not committed)
Ran all 10 combos (llama3.2:latest, qwen3:8b, gemma4:latest, mistral:7b, phi4:latest x variant_a, variant_b). Human spot-checked a sample of judge verdicts against their transcripts — judge reasoning tracked what a human reviewer would conclude, including correctly catching a clear failure (mistral:7b/variant_a hallucinated an unrelated physics problem and leaked its own system prompt into the conversation).

**Follow-up finding (not fixed here):** phi4:latest/variant_b hallucinated the entire multi-turn dialogue (both tutor and fake student turns) in one completion. The judge only checks vocabulary/comprehensibility, not turn-taking structure, so this needs a harness-side check in a later issue.

## Test plan
- [x] `uv run pytest tests/vocab_eval/ -vv` — 24 new tests, all passing
- [x] `uv run pytest tests/ -m 'not integration' -n 2` — full backend suite green (re-ran 3x to confirm no flakiness)
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `pre-commit run --all-files` on changed files — all hooks pass